### PR TITLE
Bump kubernetes python client dependency to 12.0.0b1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-kubernetes>=11.0
+kubernetes==12.0.0b1
 mock


### PR DESCRIPTION
Currently the python SDK is using kubernetes 11.0.0. I'd like to see it updated to 12.0.0b1, as this brings some improves to incluster config initialization (and likely other things as well). The new version is a pre-release version though, but it seems to work fine from my limited testing.