### PR TITLE
Downgrade k8s Python SDK to >=11.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-kubernetes==12.0.0b1
+kubernetes>=11.0.0
 mock


### PR DESCRIPTION
Couler currently requires it to be 11.0.0. See context in https://github.com/couler-proj/couler/pull/56. 

Users of argo-client-python can still use a newer version number but it should not be a requirement.