### PR TITLE
cronworkflows status can contains empty values

### DIFF
--- a/argo/workflows/client/models/v1alpha1_cron_workflow_status.py
+++ b/argo/workflows/client/models/v1alpha1_cron_workflow_status.py
@@ -80,7 +80,7 @@ class V1alpha1CronWorkflowStatus(object):
         :type: list[V1ObjectReference]
         """
         if self.local_vars_configuration.client_side_validation and active is None:  # noqa: E501
-            raise ValueError("Invalid value for `active`, must not be `None`")  # noqa: E501
+            self._active = "null"
 
         self._active = active
 
@@ -105,7 +105,7 @@ class V1alpha1CronWorkflowStatus(object):
         :type: list[V1alpha1Condition]
         """
         if self.local_vars_configuration.client_side_validation and conditions is None:  # noqa: E501
-            raise ValueError("Invalid value for `conditions`, must not be `None`")  # noqa: E501
+            self._conditions = "null"
 
         self._conditions = conditions
 
@@ -130,7 +130,7 @@ class V1alpha1CronWorkflowStatus(object):
         :type: datetime
         """
         if self.local_vars_configuration.client_side_validation and last_scheduled_time is None:  # noqa: E501
-            raise ValueError("Invalid value for `last_scheduled_time`, must not be `None`")  # noqa: E501
+            self._last_scheduled_time = "null"
 
         self._last_scheduled_time = last_scheduled_time
 


### PR DESCRIPTION
While this is not ideal in any way, **the purpose of this PR is strictly to provide a working solution for cronworkflows** for those who seeks it.

1. Cronworkflows functionality is pretty much limited at the moment (5.0.0) due to certain values being retuned as None as in the response when creating a cronworkflow, this response is being handled by the V1alpha1CronWorkflowStatus model. 
2. Having nulls in the response is fine and that's an expected behavior when the created cronworkflow doesn't have that information yet.
3. This sceanrio is not covered by the model, therefore, any newly created cronworkflow or a querying for cronworkflow that didn't execute yet will result in ValueError exception.